### PR TITLE
fix: fix qos warn && qos rules redundancy when ip changed

### DIFF
--- a/pkg/network/iptables.go
+++ b/pkg/network/iptables.go
@@ -129,15 +129,14 @@ func (ru IPRule) Args() []string {
 	if ru.Output != "" {
 		args = append(args, "-o", ru.Output)
 	}
-	if ru.Comment != "" {
-		args = append(args, "-m", "comment", "--comment", ru.Comment)
-	}
-
 	if ru.Limit != "" {
 		args = append(args, "-m", "limit", "--limit", ru.Limit)
 	}
 	if ru.LimitBurst != "" {
 		args = append(args, "--limit-burst", ru.LimitBurst)
+	}
+	if ru.Comment != "" {
+		args = append(args, "-m", "comment", "--comment", ru.Comment)
 	}
 
 	if ru.Jump != "" {


### PR DESCRIPTION
** 修复 #56**
关于这个PR截图所示问题
mangle表现有规则

```bash
-A Qos_example-in-dgbw8gq -m limit --limit 105/sec --limit-burst 100 -m comment --comment "Qos Limit In hi@example" -j ACCEPT
```
工具删除时自动生成 规则
```bash
 iptables --wait -t mangle -D Qos_example-in-dgbw8gq -m comment --comment Qos Limit In hi@example -m limit --limit 105/s --limit-burst 100 -j ACCEPT
```
这里面有连个问题导致了删除报错， 
1. comment 顺序不对，与现有的表不同会删除失败
2. comment 后的文本需要“引号包裹

**修复 ip变化，qos规则冗余**
ip变化规则未删除原因和上面类似