### PR TITLE
feat: support get OS platform for VPNClient System

### DIFF
--- a/pkg/schema/openvpn.go
+++ b/pkg/schema/openvpn.go
@@ -14,4 +14,5 @@ type VPNClient struct {
 	State     string `json:"state"`
 	AliveTime int64  `json:"aliveTime"`
 	Address   string `json:"address"`
+	System    string `json:"system"`
 }


### PR DESCRIPTION
新增openvpn 信息中获取System 客户端操作系统类型字段 

实现方式openvpn新增 client-connect 和 client-disconnect 脚本，脚本中获取环境变量IV_PLAT 保存到文件
格式 ： name,system
![image](https://github.com/luscis/openlan/assets/9956097/6b77cb7a-1d85-46d1-8cba-32ede80913a9)

![image](https://github.com/luscis/openlan/assets/9956097/2e795af8-abdb-4c16-8826-befc994ebef9)
